### PR TITLE
feat: 정책 정보 Entity 생성 및 DB 저장 

### DIFF
--- a/src/main/java/com/twojz/y_kit/policy/controller/PolicySyncController.java
+++ b/src/main/java/com/twojz/y_kit/policy/controller/PolicySyncController.java
@@ -1,0 +1,30 @@
+package com.twojz.y_kit.policy.controller;
+
+import com.twojz.y_kit.policy.service.PolicySyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/policy-sync")
+@RequiredArgsConstructor
+public class PolicySyncController {
+    private final PolicySyncService policySyncService;
+
+    @GetMapping("/trigger")
+    public ResponseEntity<String> triggerSync() {
+        log.info("수동 정책 동기화 요청");
+        try {
+            policySyncService.syncAllPolicies();
+            return ResponseEntity.ok("정책 동기화가 시작되었습니다.");
+        } catch (Exception e) {
+            log.error("정책 동기화 트리거 실패", e);
+            return ResponseEntity.internalServerError()
+                    .body("정책 동기화 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyApplicationEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyApplicationEntity.java
@@ -1,0 +1,50 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import com.twojz.y_kit.policy.entity.enums.ApplicationPeriodType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_application", indexes = {
+        @Index(name = "idx_policy_id", columnList = "policy_id")
+})
+@Entity
+public class PolicyApplicationEntity extends BaseEntity {
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", unique = true)
+    private PolicyEntity policy;
+
+    private String sprtSclLmttYn;
+
+    private String sprtArvlSqncYn;
+
+    @Enumerated(EnumType.STRING)
+    private ApplicationPeriodType aplyPrdSeCd;
+
+    private String aplyYmd;
+
+    @Column(columnDefinition = "TEXT")
+    private String plcyAplyMthdCn;
+
+    @Column(length = 1000)
+    private String aplyUrlAddr;
+
+    @Column(columnDefinition = "TEXT")
+    private String scrnMthdCn;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyCategoryEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyCategoryEntity.java
@@ -1,0 +1,37 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.util.List;
+import lombok.*;
+
+import java.util.ArrayList;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_category", indexes = {
+        @Index(name = "idx_parent_id", columnList = "parent_id"),
+        @Index(name = "idx_name", columnList = "name"),
+        @Index(name = "idx_level", columnList = "level")
+})
+@Entity
+public class PolicyCategoryEntity extends BaseEntity {
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer level;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private PolicyCategoryEntity parent;
+
+    @OneToMany(mappedBy = "parent")
+    @Builder.Default
+    private List<PolicyCategoryEntity> children = new ArrayList<>();
+
+    @Builder.Default
+    private Boolean isActive = true;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyCategoryMapping.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyCategoryMapping.java
@@ -1,0 +1,28 @@
+package com.twojz.y_kit.policy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "policy_category_mapping", indexes = {
+        @Index(name = "idx_policy_category", columnList = "policy_id, category_id", unique = true),
+        @Index(name = "idx_category_id", columnList = "category_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PolicyCategoryMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private PolicyEntity policy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private PolicyCategoryEntity category;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyDetailEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyDetailEntity.java
@@ -1,0 +1,61 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_details", indexes = {
+        @Index(name = "idx_policy_id", columnList = "policy_id"),
+        @Index(name = "idx_plcy_no", columnList = "plcy_no")
+})
+@Entity
+public class PolicyDetailEntity extends BaseEntity {
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", unique = true)
+    private PolicyEntity policy;
+
+    @Column(unique = true)
+    private String plcyNo;
+
+    private String plcyNm;
+
+    @Column(columnDefinition = "TEXT")
+    private String plcyExplnCn;
+
+    @Column(columnDefinition = "TEXT")
+    private String plcySprtCn;
+
+    private String sprvsnInstCdNm;
+
+    private String operInstCdNm;
+
+    private String sprtSclCnt;
+
+    private String bizPrdSeCd;
+
+    private LocalDate bizPrdBgngYmd;
+
+    private LocalDate bizPrdEndYmd;
+
+    @Column(columnDefinition = "TEXT")
+    private String bizPrdEtcCn;
+
+    @Column(columnDefinition = "TEXT")
+    private String etcMttrCn;
+
+    @Column(length = 1000)
+    private String refUrlAddr1;
+
+    @Column(length = 1000)
+    private String refUrlAddr2;
+
+    @Column(columnDefinition = "TEXT")
+    private String prtcpSgstTrgtCn;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyDocumentEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyDocumentEntity.java
@@ -1,0 +1,26 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_document", indexes = {
+        @Index(name = "idx_policy_id", columnList = "policy_id")
+})
+@Entity
+public class PolicyDocumentEntity extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private PolicyEntity policy;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String documentsOriginal;
+
+    @Builder.Default
+    private Boolean isRequired = true;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyEntity.java
@@ -1,0 +1,94 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policies", indexes = {
+        @Index(name = "idx_policy_no", columnList = "policy_no"),
+        @Index(name = "idx_is_active", columnList = "is_active")
+})
+@Entity
+public class PolicyEntity extends BaseEntity {
+    @Column(unique = true, nullable = false)
+    private String policyNo;
+
+    @Builder.Default
+    private Integer viewCount = 0;
+
+    @Builder.Default
+    private Integer bookmarkCount = 0;
+
+    @Builder.Default
+    private Integer applicationCount = 0;
+
+    @Builder.Default
+    private Boolean isActive = true;
+
+    // 연관 관계
+    @OneToOne(mappedBy = "policy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private PolicyDetailEntity detail;
+
+    @OneToOne(mappedBy = "policy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private PolicyQualificationEntity qualification;
+
+    @OneToOne(mappedBy = "policy", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private PolicyApplicationEntity application;
+
+    @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PolicyDocumentEntity> documents = new ArrayList<>();
+
+    @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PolicyRegion> policyRegions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PolicyCategoryMapping> categoryMappings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "policy", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<PolicyKeywordMapping> keywordMappings = new ArrayList<>();
+
+    // 비즈니스 메서드
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void increaseBookmarkCount() {
+        this.bookmarkCount++;
+    }
+
+    public void decreaseBookmarkCount() {
+        if (this.bookmarkCount > 0) {
+            this.bookmarkCount--;
+        }
+    }
+
+    public void increaseApplicationCount() {
+        this.applicationCount++;
+    }
+
+    public void setApplication(PolicyApplicationEntity application) {
+        this.application = application;
+    }
+
+    public void setDetail(PolicyDetailEntity detail) {
+        this.detail = detail;
+    }
+
+    public void setQualification(PolicyQualificationEntity qualification) {
+        this.qualification = qualification;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyKeywordEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyKeywordEntity.java
@@ -1,0 +1,26 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_keyword", indexes = {
+        @Index(name = "idx_keyword", columnList = "keyword")
+})
+@Entity
+public class PolicyKeywordEntity extends BaseEntity {
+    @Column(name = "keyword", unique = true, nullable = false)
+    private String keyword;
+
+    @Column(name = "usage_count")
+    @Builder.Default
+    private Integer usageCount = 0;
+
+    public void increaseUsageCount() {
+        this.usageCount++;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyKeywordMapping.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyKeywordMapping.java
@@ -1,0 +1,29 @@
+package com.twojz.y_kit.policy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "policy_keyword_mapping", indexes = {
+        @Index(name = "idx_policy_keyword", columnList = "policy_id, keyword_id", unique = true),
+        @Index(name = "idx_keyword_id", columnList = "keyword_id")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+public class PolicyKeywordMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private PolicyEntity policy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id", nullable = false)
+    private PolicyKeywordEntity keyword;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyQualificationEntity.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyQualificationEntity.java
@@ -1,0 +1,100 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import com.twojz.y_kit.policy.entity.enums.*;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_qualification", indexes = {
+        @Index(name = "idx_policy_id", columnList = "policy_id"),
+        @Index(name = "idx_age", columnList = "sprt_trgt_min_age, sprt_trgt_max_age")
+})
+@Entity
+public class PolicyQualificationEntity extends BaseEntity {
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", unique = true)
+    private PolicyEntity policy;
+
+    // 연령 요건
+    @Column(name = "sprt_trgt_age_lmtt_yn")
+    private String sprtTrgtAgeLmttYn;
+
+    @Column(name = "sprt_trgt_min_age")
+    private Integer sprtTrgtMinAge;
+
+    @Column(name = "sprt_trgt_max_age")
+    private Integer sprtTrgtMaxAge;
+
+    // 소득 요건
+    @Enumerated(EnumType.STRING)
+    @Column(name = "earn_cnd_se_cd")
+    private IncomeConditionType earnCndSeCd;
+
+    @Column(name = "earn_min_amt", precision = 15, scale = 2)
+    private BigDecimal earnMinAmt;
+
+    @Column(name = "earn_max_amt", precision = 15, scale = 2)
+    private BigDecimal earnMaxAmt;
+
+    @Column(name = "earn_etc_cn", columnDefinition = "TEXT")
+    private String earnEtcCn;
+
+    // 결혼 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mrg_stts_cd")
+    private MaritalStatus mrgSttsCd;
+
+    // 학력/취업/전공/특화 요건
+    @Enumerated(EnumType.STRING)
+    @Column(name = "school_cd")
+    private EducationLevel schoolCd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_cd")
+    private EmploymentStatus jobCd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "plcy_major_cd")
+    private MajorField plcyMajorCd;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sbiz_cd")
+    private SpecializedRequirement sbizCd;
+
+    @Column(name = "add_aply_qlfcn_cn", columnDefinition = "TEXT")
+    private String addAplyQlfcnCn;
+
+    // 비즈니스 메서드
+    public boolean isAgeEligible(int age) {
+        if (sprtTrgtMinAge == null && sprtTrgtMaxAge == null) {
+            return true;
+        }
+        if (sprtTrgtMinAge != null && age < sprtTrgtMinAge) {
+            return false;
+        }
+        if (sprtTrgtMaxAge != null && age > sprtTrgtMaxAge) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean isIncomeEligible(BigDecimal income) {
+        if (earnMinAmt == null && earnMaxAmt == null) {
+            return true;
+        }
+        if (earnMinAmt != null && income.compareTo(earnMinAmt) < 0) {
+            return false;
+        }
+        if (earnMaxAmt != null && income.compareTo(earnMaxAmt) > 0) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/PolicyRegion.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/PolicyRegion.java
@@ -1,0 +1,38 @@
+package com.twojz.y_kit.policy.entity;
+
+import com.twojz.y_kit.global.entity.BaseEntity;
+import com.twojz.y_kit.region.entity.Region;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "policy_region", indexes = {
+        @Index(name = "idx_policy_region", columnList = "policy_id, region_id", unique = true),
+        @Index(name = "idx_region_id", columnList = "region_id")
+})
+@Entity
+@Getter
+public class PolicyRegion extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private PolicyEntity policy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/ApplicationPeriodType.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/ApplicationPeriodType.java
@@ -1,0 +1,30 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 신청기간 구분 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ApplicationPeriodType {
+    CODE_57001("57001", "특정기간"),
+    CODE_57002("57002", "상시"),
+    CODE_57003("57003", "마감");
+
+    private final String code;
+    private final String description;
+
+    public static ApplicationPeriodType fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (ApplicationPeriodType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/EducationLevel.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/EducationLevel.java
@@ -1,0 +1,37 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 정책 학력 요건 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum EducationLevel {
+    CODE_49001("49001", "고졸 미만"),
+    CODE_49002("49002", "고교 재학"),
+    CODE_49003("49003", "고졸 예정"),
+    CODE_49004("49004", "고교 졸업"),
+    CODE_49005("49005", "대학 재학"),
+    CODE_49006("49006", "대졸 예정"),
+    CODE_49007("49007", "대학 졸업"),
+    CODE_49008("49008", "석·박사"),
+    CODE_49009("49009", "기타"),
+    CODE_49010("49010", "제한없음");
+
+    private final String code;
+    private final String description;
+
+    public static EducationLevel fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (EducationLevel level : values()) {
+            if (level.code.equals(code)) {
+                return level;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/EmploymentStatus.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/EmploymentStatus.java
@@ -1,0 +1,37 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 정책 취업 요건 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum EmploymentStatus {
+    CODE_13001("13001", "재직자"),
+    CODE_13002("13002", "자영업자"),
+    CODE_13003("13003", "미취업자"),
+    CODE_13004("13004", "프리랜서"),
+    CODE_13005("13005", "일용근로자"),
+    CODE_13006("13006", "(예비)창업자"),
+    CODE_13007("13007", "단기근로자"),
+    CODE_13008("13008", "영농종사자"),
+    CODE_13009("13009", "기타"),
+    CODE_13010("13010", "제한없음");
+
+    private final String code;
+    private final String description;
+
+    public static EmploymentStatus fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (EmploymentStatus status : values()) {
+            if (status.code.equals(code)) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/IncomeConditionType.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/IncomeConditionType.java
@@ -1,0 +1,30 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 소득 조건 구분 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum IncomeConditionType {
+    CODE_43001("43001", "무관"),
+    CODE_43002("43002", "연소득"),
+    CODE_43003("43003", "기타");
+
+    private final String code;
+    private final String description;
+
+    public static IncomeConditionType fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (IncomeConditionType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/MajorField.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/MajorField.java
@@ -1,0 +1,36 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 정책 전공 요건 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MajorField {
+    CODE_11001("11001", "인문계열"),
+    CODE_11002("11002", "사회계열"),
+    CODE_11003("11003", "상경계열"),
+    CODE_11004("11004", "이학계열"),
+    CODE_11005("11005", "공학계열"),
+    CODE_11006("11006", "예체능계열"),
+    CODE_11007("11007", "농산업계열"),
+    CODE_11008("11008", "기타"),
+    CODE_11009("11009", "제한없음");
+
+    private final String code;
+    private final String description;
+
+    public static MajorField fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (MajorField field : values()) {
+            if (field.code.equals(code)) {
+                return field;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/MaritalStatus.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/MaritalStatus.java
@@ -1,0 +1,30 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 결혼 상태 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum MaritalStatus {
+    CODE_55001("55001", "기혼"),
+    CODE_55002("55002", "미혼"),
+    CODE_55003("55003", "제한없음");
+
+    private final String code;
+    private final String description;
+
+    public static MaritalStatus fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (MaritalStatus status : values()) {
+            if (status.code.equals(code)) {
+                return status;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/twojz/y_kit/policy/entity/enums/SpecializedRequirement.java
+++ b/src/main/java/com/twojz/y_kit/policy/entity/enums/SpecializedRequirement.java
@@ -1,0 +1,38 @@
+package com.twojz.y_kit.policy.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 정책 특화 요건 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SpecializedRequirement {
+    CODE_14001("14001", "중소기업"),
+    CODE_14002("14002", "여성"),
+    CODE_14003("14003", "기초생활수급자"),
+    CODE_14004("14004", "한부모가정"),
+    CODE_14005("14005", "장애인"),
+    CODE_14006("14006", "농업인"),
+    CODE_14007("14007", "군인"),
+    CODE_14008("14008", "지역인재"),
+    CODE_14009("14009", "기타"),
+    CODE_14010("14010", "제한없음");
+
+    private final String code;
+    private final String description;
+
+    public static SpecializedRequirement fromCode(String code) {
+        if (code == null || code.trim().isEmpty()) {
+            return null;
+        }
+        for (SpecializedRequirement req : values()) {
+            if (req.code.equals(code)) {
+                return req;
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/twojz/y_kit/policy/repository/PolicyCategoryRepository.java
+++ b/src/main/java/com/twojz/y_kit/policy/repository/PolicyCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.twojz.y_kit.policy.repository;
+
+import com.twojz.y_kit.policy.entity.PolicyCategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PolicyCategoryRepository extends JpaRepository<PolicyCategoryEntity, Long> {
+    Optional<PolicyCategoryEntity> findByNameAndLevel(String name, Integer level);
+}

--- a/src/main/java/com/twojz/y_kit/policy/repository/PolicyDetailRepository.java
+++ b/src/main/java/com/twojz/y_kit/policy/repository/PolicyDetailRepository.java
@@ -1,0 +1,16 @@
+package com.twojz.y_kit.policy.repository;
+
+
+import com.twojz.y_kit.policy.entity.PolicyDetailEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PolicyDetailRepository extends JpaRepository<PolicyDetailEntity, Long> {
+    Optional<PolicyDetailEntity> findByPlcyNo(String plcyNo);
+
+    @Query("SELECT d FROM PolicyDetailEntity d JOIN FETCH d.policy WHERE d.plcyNo = :plcyNo")
+    Optional<PolicyDetailEntity> findByPlcyNoWithPolicy(@Param("plcyNo") String plcyNo);
+
+}

--- a/src/main/java/com/twojz/y_kit/policy/repository/PolicyKeywordRepository.java
+++ b/src/main/java/com/twojz/y_kit/policy/repository/PolicyKeywordRepository.java
@@ -1,0 +1,11 @@
+package com.twojz.y_kit.policy.repository;
+
+import com.twojz.y_kit.policy.entity.PolicyKeywordEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PolicyKeywordRepository extends JpaRepository<PolicyKeywordEntity, Long> {
+    Optional<PolicyKeywordEntity> findByKeyword(String keyword);
+}

--- a/src/main/java/com/twojz/y_kit/policy/repository/PolicyRepository.java
+++ b/src/main/java/com/twojz/y_kit/policy/repository/PolicyRepository.java
@@ -1,0 +1,11 @@
+package com.twojz.y_kit.policy.repository;
+
+import com.twojz.y_kit.policy.entity.PolicyEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PolicyRepository extends JpaRepository<PolicyEntity, Long> {
+    Optional<PolicyEntity> findByPolicyNo(String policyNo);
+}

--- a/src/main/java/com/twojz/y_kit/policy/service/PolicySyncService.java
+++ b/src/main/java/com/twojz/y_kit/policy/service/PolicySyncService.java
@@ -1,0 +1,272 @@
+package com.twojz.y_kit.policy.service;
+
+import com.twojz.y_kit.external.policy.client.YouthPolicyClient;
+import com.twojz.y_kit.external.policy.dto.YouthPolicy;
+import com.twojz.y_kit.policy.entity.*;
+import com.twojz.y_kit.policy.entity.enums.*;
+import com.twojz.y_kit.policy.repository.*;
+import com.twojz.y_kit.region.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PolicySyncService {
+
+    private final YouthPolicyClient youthPolicyClient;
+    private final PolicyRepository policyRepository;
+    private final PolicyDetailRepository policyDetailRepository;
+    private final PolicyCategoryRepository policyCategoryRepository;
+    private final PolicyKeywordRepository policyKeywordRepository;
+    private final RegionRepository regionRepository;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    /** 정책 전체 동기화 */
+    @Transactional
+    public void syncAllPolicies() {
+        log.info("정책 동기화 시작");
+
+        youthPolicyClient.fetchAllPolicies()
+                .subscribe(
+                        policies -> {
+                            log.info("총 {}개 정책 동기화 시작", policies.size());
+
+                            int successCount = 0;
+                            int failCount = 0;
+
+                            for (YouthPolicy apiPolicy : policies) {
+                                try {
+                                    saveOrUpdatePolicy(apiPolicy);
+                                    successCount++;
+
+                                    if (successCount % 100 == 0) {
+                                        log.info("진행 중: {}/{}", successCount, policies.size());
+                                    }
+                                } catch (Exception e) {
+                                    log.error("정책 저장 실패: {}", apiPolicy.getPlcyNo(), e);
+                                    failCount++;
+                                }
+                            }
+
+                            log.info("정책 동기화 완료 - 성공: {}, 실패: {}", successCount, failCount);
+                        },
+                        error -> log.error("정책 동기화 중 오류 발생", error)
+                );
+    }
+
+    /** 단일 정책 저장/업데이트 */
+    @Transactional
+    public void saveOrUpdatePolicy(YouthPolicy apiPolicy) {
+        PolicyEntity policy = findOrCreatePolicy(apiPolicy);
+
+        PolicyDetailEntity detail = buildPolicyDetail(apiPolicy, policy);
+        PolicyQualificationEntity qualification = buildQualification(apiPolicy, policy);
+        PolicyApplicationEntity application = buildApplication(apiPolicy, policy);
+
+        policy.setDetail(detail);
+        policy.setQualification(qualification);
+        policy.setApplication(application);
+
+        mapRegions(apiPolicy, policy);
+        mapDocuments(apiPolicy, policy);
+        mapCategories(apiPolicy, policy);
+        mapKeywords(apiPolicy, policy);
+
+        policyRepository.save(policy);
+        log.debug("정책 저장 완료: {}", apiPolicy.getPlcyNo());
+    }
+
+    private PolicyEntity findOrCreatePolicy(YouthPolicy apiPolicy) {
+        return policyDetailRepository.findByPlcyNo(apiPolicy.getPlcyNo())
+                .map(PolicyDetailEntity::getPolicy)
+                .orElseGet(() -> PolicyEntity.builder()
+                        .policyNo(apiPolicy.getPlcyNo())
+                        .viewCount(parseIntOrDefault(apiPolicy.getInqCnt(), 0))
+                        .isActive(true)
+                        .build());
+    }
+
+    private PolicyDetailEntity buildPolicyDetail(YouthPolicy apiPolicy, PolicyEntity policy) {
+        return PolicyDetailEntity.builder()
+                .policy(policy)
+                .plcyNo(apiPolicy.getPlcyNo())
+                .plcyNm(apiPolicy.getPlcyNm())
+                .plcyExplnCn(apiPolicy.getPlcyExplnCn())
+                .plcySprtCn(apiPolicy.getPlcySprtCn())
+                .sprvsnInstCdNm(apiPolicy.getSprvsnInstCdNm())
+                .operInstCdNm(apiPolicy.getOperInstCdNm())
+                .sprtSclCnt(apiPolicy.getSprtSclCnt())
+                .bizPrdSeCd(apiPolicy.getBizPrdSeCd())
+                .bizPrdBgngYmd(parseDate(apiPolicy.getBizPrdBgngYmd()))
+                .bizPrdEndYmd(parseDate(apiPolicy.getBizPrdEndYmd()))
+                .bizPrdEtcCn(apiPolicy.getBizPrdEtcCn())
+                .etcMttrCn(apiPolicy.getEtcMttrCn())
+                .refUrlAddr1(apiPolicy.getRefUrlAddr1())
+                .refUrlAddr2(apiPolicy.getRefUrlAddr2())
+                .prtcpSgstTrgtCn(apiPolicy.getPtcpPrpTrgtCn())
+                .build();
+    }
+
+    private PolicyQualificationEntity buildQualification(YouthPolicy apiPolicy, PolicyEntity policy) {
+        return PolicyQualificationEntity.builder()
+                .policy(policy)
+                .sprtTrgtAgeLmttYn(apiPolicy.getSprtTrgtAgeLmtYn())
+                .sprtTrgtMinAge(parseIntOrNull(apiPolicy.getSprtTrgtMinAge()))
+                .sprtTrgtMaxAge(parseIntOrNull(apiPolicy.getSprtTrgtMaxAge()))
+                .earnCndSeCd(IncomeConditionType.fromCode(apiPolicy.getEarnCndSeCd()))
+                .earnMinAmt(parseBigDecimalOrNull(apiPolicy.getEarnMinAmt()))
+                .earnMaxAmt(parseBigDecimalOrNull(apiPolicy.getEarnMaxAmt()))
+                .earnEtcCn(apiPolicy.getEarnEtcCn())
+                .mrgSttsCd(MaritalStatus.fromCode(apiPolicy.getMrgSttsCd()))
+                .schoolCd(EducationLevel.fromCode(apiPolicy.getSchoolCd()))
+                .jobCd(EmploymentStatus.fromCode(apiPolicy.getJobCd()))
+                .plcyMajorCd(MajorField.fromCode(apiPolicy.getPlcyMajorCd()))
+                .sbizCd(SpecializedRequirement.fromCode(apiPolicy.getSBizCd()))
+                .addAplyQlfcnCn(apiPolicy.getAddAplyQlfcCndCn())
+                .build();
+    }
+
+    private PolicyApplicationEntity buildApplication(YouthPolicy apiPolicy, PolicyEntity policy) {
+        return PolicyApplicationEntity.builder()
+                .policy(policy)
+                .sprtSclLmttYn(apiPolicy.getSprtSclLmtYn())
+                .sprtArvlSqncYn(apiPolicy.getSprtArvlSeqYn())
+                .aplyPrdSeCd(ApplicationPeriodType.fromCode(apiPolicy.getAplyPrdSeCd()))
+                .aplyYmd(apiPolicy.getAplyYmd())
+                .plcyAplyMthdCn(apiPolicy.getPlcyAplyMthdCn())
+                .aplyUrlAddr(apiPolicy.getAplyUrlAddr())
+                .scrnMthdCn(apiPolicy.getSrngMthdCn())
+                .build();
+    }
+
+    private void mapRegions(YouthPolicy apiPolicy, PolicyEntity policy) {
+        policy.getPolicyRegions().clear();
+        if (apiPolicy.getZipCd() == null || apiPolicy.getZipCd().isBlank()) return;
+
+        for (String zip : apiPolicy.getZipCd().split(",")) {
+            String trimmed = zip.trim();
+            if (!trimmed.isEmpty()) {
+                regionRepository.findById(trimmed)
+                        .ifPresent(region -> policy.getPolicyRegions().add(
+                                PolicyRegion.builder().policy(policy).region(region).build()
+                        ));
+            }
+        }
+    }
+
+    private void mapDocuments(YouthPolicy apiPolicy, PolicyEntity policy) {
+        policy.getDocuments().clear();
+        if (apiPolicy.getSbmsnDcmntCn() == null || apiPolicy.getSbmsnDcmntCn().isBlank()) return;
+
+        for (String doc : apiPolicy.getSbmsnDcmntCn().split("\n")) {
+            String trimmed = doc.trim();
+            if (!trimmed.isEmpty()) {
+                policy.getDocuments().add(
+                        PolicyDocumentEntity.builder()
+                                .policy(policy)
+                                .documentsOriginal(trimmed)
+                                .isRequired(true)
+                                .build()
+                );
+            }
+        }
+    }
+
+    private void mapCategories(YouthPolicy apiPolicy, PolicyEntity policy) {
+        policy.getCategoryMappings().clear();
+
+        if (apiPolicy.getLclsfNm() == null || apiPolicy.getLclsfNm().isBlank()) return;
+
+        PolicyCategoryEntity main = findOrCreateCategory(apiPolicy.getLclsfNm().trim(), 1, null);
+        policy.getCategoryMappings().add(
+                PolicyCategoryMapping.builder().policy(policy).category(main).build()
+        );
+
+        if (apiPolicy.getMclsfNm() != null && !apiPolicy.getMclsfNm().isBlank()) {
+            PolicyCategoryEntity sub = findOrCreateCategory(apiPolicy.getMclsfNm().trim(), 2, main);
+            policy.getCategoryMappings().add(
+                    PolicyCategoryMapping.builder().policy(policy).category(sub).build()
+            );
+        }
+    }
+
+    private void mapKeywords(YouthPolicy apiPolicy, PolicyEntity policy) {
+        policy.getKeywordMappings().clear();
+        if (apiPolicy.getPlcyKywdNm() == null || apiPolicy.getPlcyKywdNm().isBlank()) return;
+
+        for (String kw : apiPolicy.getPlcyKywdNm().split(",")) {
+            String trimmed = kw.trim();
+            if (!trimmed.isEmpty()) {
+                PolicyKeywordEntity keyword = findOrCreateKeyword(trimmed);
+                policy.getKeywordMappings().add(
+                        PolicyKeywordMapping.builder().policy(policy).keyword(keyword).build()
+                );
+            }
+        }
+    }
+
+    private PolicyCategoryEntity findOrCreateCategory(String name, int level, PolicyCategoryEntity parent) {
+        return policyCategoryRepository.findByNameAndLevel(name, level)
+                .orElseGet(() -> policyCategoryRepository.save(
+                        PolicyCategoryEntity.builder()
+                                .name(name)
+                                .level(level)
+                                .parent(parent)
+                                .isActive(true)
+                                .build()
+                ));
+    }
+
+    private PolicyKeywordEntity findOrCreateKeyword(String keywordText) {
+        return policyKeywordRepository.findByKeyword(keywordText)
+                .orElseGet(() -> policyKeywordRepository.save(
+                        PolicyKeywordEntity.builder()
+                                .keyword(keywordText)
+                                .usageCount(0)
+                                .build()
+                ));
+    }
+
+    private LocalDate parseDate(String dateStr) {
+        if (dateStr == null || dateStr.trim().isEmpty()) return null;
+        try {
+            return LocalDate.parse(dateStr.trim(), DATE_FORMATTER);
+        } catch (Exception e) {
+            log.warn("날짜 파싱 실패: {}", dateStr);
+            return null;
+        }
+    }
+
+    private Integer parseIntOrNull(String value) {
+        if (value == null || value.trim().isEmpty()) return null;
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            log.warn("숫자 파싱 실패: {}", value);
+            return null;
+        }
+    }
+
+    private Integer parseIntOrDefault(String value, int defaultValue) {
+        Integer parsed = parseIntOrNull(value);
+        return parsed != null ? parsed : defaultValue;
+    }
+
+    private BigDecimal parseBigDecimalOrNull(String value) {
+        if (value == null || value.trim().isEmpty()) return null;
+        try {
+            return new BigDecimal(value.trim());
+        } catch (NumberFormatException e) {
+            log.warn("BigDecimal 파싱 실패: {}", value);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- #17 
___

## 🛠️ 작업 내용
- 연동한 정책 API에서 받아온 데이터에 따라 엔티티를 세분화함 (policy, policy_document, policy_detail, policy_application, policy_category, policy_keyword)
- 정책 데이터를 각 엔티티에 저장
___

## ✅ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

___

## 📎 참고 자료 